### PR TITLE
Check for sops metadata when detecting encrypted file

### DIFF
--- a/src/utilities/functions.ts
+++ b/src/utilities/functions.ts
@@ -190,17 +190,21 @@ export async function isSopsEncrypted(file:Uri) : Promise<boolean> {
 		const pr: PatternSet = _getSopsPatternsFromFile(sf);
 		for (const re of pr[1]) {
 			if (new RegExp(`${pr[0]}/.*${re}`).test(file.path)) {
-				const fileSize = (await fspromises.stat(file.path)).size
+				const fileSize = (await fspromises.stat(file.path)).size;
 				if (fileSize > (1024 * 1024)) {
 					return false; // probably too big to care, too big to parse
 				}
 				const contentString: string = readFileSync(file.path, 'utf-8');
 				// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+				try {
+					// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 				const content = parse(contentString);
-				if (content.hasOwnProperty("sops")) {
+					if (Object.prototype.hasOwnProperty.call(content, "sops")) {
 				return true;
 				}
-
+				} catch (error) {
+					return false;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
I'm not very good with JS/TS, and this is my first look at a vscode extension, but this solves the problem I reported in #5 for me. 

The patch attempts to parse any file that matches the `.sops.yaml` pattern as yaml and looks for a top-level `sops` key. If the key is found, it's assumed to be a sops encrypted file. Otherwise, it's not a sops file and is opened normally. 

I put in a check to not try to parse files greater than 1Mb, they're probably not files you'd want to edit anyway. I don't know if that's a good limit or it should be raised. I didn't try opening bigger files.

Suggestions and feedback welcome!

Fixes #5  