### PR TITLE
Decrypt encrypt buttons on right editors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 0.0.8
+- Updated `Decrypt` and `Encrypt` button logic
+  - Editor will only show `Decrypt` button if file is encrypted, and `Encrypt` when matching `.sops.yaml` regexes but not encrypted
+  - Editor will not show `Decrypt` or `Encrypt` buttons when it's showing a GIT diff
+
 ## 0.0.7
 - Extension will no longer close the editor tab when it's showing a GIT diff (solving [#7](https://github.com/ShipitSmarter/vscode-sops-edit/issues/7))
 

--- a/README.md
+++ b/README.md
@@ -46,11 +46,13 @@ This extension adds the following event listeners:
 
 ![Decrypt encrypt](https://raw.githubusercontent.com/shipitsmarter/vscode-sops-edit/main/img/editor_decrypt_encrypt.png)
 
-This extension adds the following buttons to the top-right editor menu of every SOPS encrypted file `*`:
+This extension adds the following buttons to the top-right editor menu of every SOPS encrypted or *encryptable* file `*`:
 - `Decrypt`
   - Decrypts the file in-place
+  - Only shown when file is SOPS encrypted
 - `Encrypt`
   - Encrypts the file in-place
+  - Only shown when file is *encryptable* but not actually encrypted
 
 
 `*` I.e., any file that satisfies any of the combinations of `.sops.yaml` file paths and their `path_regex` conditions.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sops-edit",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "sops-edit",
-      "version": "0.0.7",
+      "version": "0.0.8",
       "dependencies": {
         "child_process": "^1.0.2",
         "fs": "^0.0.1-security",

--- a/package.json
+++ b/package.json
@@ -63,12 +63,12 @@
       ],
       "editor/title": [
 				{
-					"when": "sops-edit.isSopsEncrypted",
+					"when": "sops-edit.isSopsEncryptable",
 					"command": "sops-edit.decrypt-editor",
 					"group": "navigation"
 				},
         {
-					"when": "sops-edit.isSopsEncrypted",
+					"when": "sops-edit.isSopsEncryptable",
 					"command": "sops-edit.encrypt-editor",
 					"group": "navigation"
 				}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "sops-edit",
   "displayName": "SOPS easy edit",
   "description": "Never again worry about encrypting, decrypting or accidentally committing decrypted files.",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "publisher": "ShipitSmarter",
   "author": {
     "name": "ShipitSmarter",

--- a/package.json
+++ b/package.json
@@ -63,12 +63,12 @@
       ],
       "editor/title": [
 				{
-					"when": "sops-edit.isSopsEncryptable",
+					"when": "sops-edit.isEncrypted",
 					"command": "sops-edit.decrypt-editor",
 					"group": "navigation"
 				},
         {
-					"when": "sops-edit.isSopsEncryptable",
+					"when": "sops-edit.isEncryptable",
 					"command": "sops-edit.encrypt-editor",
 					"group": "navigation"
 				}

--- a/src/utilities/EditorContext.ts
+++ b/src/utilities/EditorContext.ts
@@ -1,13 +1,15 @@
 import { TextEditor, commands } from "vscode";
-import { isSopsEncrypted } from "./functions";
+import { isOpenedInPlainTextEditor, isSopsEncryptable } from "./functions";
 
 export class EditorContext {
     public static set(editor:TextEditor|undefined) : void {
-        void this._setIsSopsEncrypted(editor);        
+        void this._setIsSopsEncryptable(editor);        
     }
 
-    private static async _setIsSopsEncrypted(editor:TextEditor|undefined) : Promise<void> {
-        const isSopsEncryptedBool = editor ? await isSopsEncrypted(editor.document.uri) : false;
-        void commands.executeCommand('setContext', 'sops-edit.isSopsEncrypted', isSopsEncryptedBool ); 
+    private static async _setIsSopsEncryptable(editor:TextEditor|undefined) : Promise<void> {
+        const isSopsEncryptableBool = editor 
+            ? await isSopsEncryptable(editor.document.uri) && await isOpenedInPlainTextEditor(editor.document.uri)
+            : false;
+        void commands.executeCommand('setContext', 'sops-edit.isSopsEncryptable', isSopsEncryptableBool ); 
     }
 }

--- a/src/utilities/EditorContext.ts
+++ b/src/utilities/EditorContext.ts
@@ -1,15 +1,23 @@
 import { TextEditor, commands } from "vscode";
-import { isOpenedInPlainTextEditor, isSopsEncryptable } from "./functions";
+import { isOpenedInPlainTextEditor, isSopsEncryptable, isSopsEncrypted, isEncryptableAndEncrypted} from "./functions";
 
 export class EditorContext {
     public static set(editor:TextEditor|undefined) : void {
-        void this._setIsSopsEncryptable(editor);        
+        void this._setIsEncryptable(editor);
+        void this._setIsSopsEncrypted(editor);
     }
 
-    private static async _setIsSopsEncryptable(editor:TextEditor|undefined) : Promise<void> {
+    private static async _setIsEncryptable(editor:TextEditor|undefined) : Promise<void> {
         const isSopsEncryptableBool = editor 
-            ? await isSopsEncryptable(editor.document.uri) && await isOpenedInPlainTextEditor(editor.document.uri)
+            ? await isSopsEncryptable(editor.document.uri)  && await isOpenedInPlainTextEditor(editor.document.uri) && !(await isEncryptableAndEncrypted(editor.document.uri))
             : false;
-        void commands.executeCommand('setContext', 'sops-edit.isSopsEncryptable', isSopsEncryptableBool ); 
+        void commands.executeCommand('setContext', 'sops-edit.isEncryptable', isSopsEncryptableBool ); 
+    }
+
+    private static async _setIsSopsEncrypted(editor:TextEditor|undefined) : Promise<void> {
+        const isSopsEncryptedBool = editor 
+            ? await isOpenedInPlainTextEditor(editor.document.uri) && await isSopsEncrypted(editor.document.uri)
+            : false;
+        void commands.executeCommand('setContext', 'sops-edit.isEncrypted', isSopsEncryptedBool );
     }
 }

--- a/src/utilities/FilePool.ts
+++ b/src/utilities/FilePool.ts
@@ -39,8 +39,8 @@ export class FilePool {
             return;
         }
 
-        const isOpenInNonDiffEditor: boolean = await f.closeFileIfOpenInNonDiffEditor(encryptedFile);
-        if (!isOpenInNonDiffEditor) {
+        const isOpenInPlainTextEditor: boolean = await f.isOpenedInPlainTextEditor(encryptedFile, true);
+        if (!isOpenInPlainTextEditor) {
             return;
         }
         


### PR DESCRIPTION
- Updated `Decrypt` and `Encrypt` button logic
  - Editor will only show `Decrypt` button if file is encrypted, and `Encrypt` when matching `.sops.yaml` regexes but not encrypted
  - Editor will not show `Decrypt` or `Encrypt` buttons when it's showing a GIT diff