### PR TITLE
env ini encryption detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.0.11
+- Fixed file encryption detection for `.env` and `.ini` files (solves [#15](https://github.com/ShipitSmarter/vscode-sops-edit/issues/15))
+- Fixed editor showing `encrypt` button for decrypted `tmp` files
+
 ## 0.0.10
 - Fixed issue [#13](https://github.com/ShipitSmarter/vscode-sops-edit/issues/13) where extension would not work properly for Windows users
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.0.11
 - Fixed file encryption detection for `.env` and `.ini` files (solves [#15](https://github.com/ShipitSmarter/vscode-sops-edit/issues/15))
 - Fixed editor showing `encrypt` button for decrypted `tmp` files
+- Extension will now only activate for workspaces containing at least one `.sops.yaml` file
 
 ## 0.0.10
 - Fixed issue [#13](https://github.com/ShipitSmarter/vscode-sops-edit/issues/13) where extension would not work properly for Windows users

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ This extension does NOT do or help with any of the following:
 
 ## Dependencies
 This extension happily makes use of the following outstanding `npm` packages:
-- [NodeJs](https://nodejs.org/en/)'s:
-  - [File System API](https://nodejs.org/api/fs.html)
-  - [Child process](https://nodejs.org/api/child_process.html)
+- [File System API](https://nodejs.org/api/fs.html)
+- [Child process](https://nodejs.org/api/child_process.html)
+- [ini](https://www.npmjs.com/package/ini)
 - [eemeli](https://www.npmjs.com/~eemeli)'s excellent [yaml](https://www.npmjs.com/package/yaml) package

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ This extension has the following limitations:
 - Only SOPS config files named `.sops.yaml` are taken into account
 - The `SOPS: edit directly` button is only available to `yaml`/`yml`/`json`/`env`/`ini`/`txt` files. Other SOPS encrypted files are rendered impossible to be edited directly by installing this extension.
 - SOPS encryption is only checked for files smaller than **1MB**
+  - Encrypted or encryptable files larger than this will be completely ignored by this extension
 
 This extension does NOT do or help with any of the following:
 - Installation of SOPS

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,10 +12,12 @@
         "@vscode/vsce": "^2.19.0",
         "child_process": "^1.0.2",
         "fs": "^0.0.1-security",
+        "ini": "^4.1.0",
         "yaml": "^2.2.2"
       },
       "devDependencies": {
         "@types/glob": "^7.2.0",
+        "@types/ini": "^1.3.31",
         "@types/mocha": "^9.1.0",
         "@types/node": "14.x",
         "@types/vscode": "^1.78.0",
@@ -141,6 +143,12 @@
         "@types/minimatch": "*",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/ini": {
+      "version": "1.3.31",
+      "resolved": "https://registry.npmjs.org/@types/ini/-/ini-1.3.31.tgz",
+      "integrity": "sha512-8ecxxaG4AlVEM1k9+BsziMw8UsX0qy3jYI1ad/71RrDZ+rdL6aZB0wLfAuflQiDhkD5o4yJ0uPK3OSUic3fG0w==",
+      "dev": true
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.11",
@@ -1947,11 +1955,12 @@
       "dev": true
     },
     "node_modules/ini": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-      "dev": true,
-      "optional": true
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.0.tgz",
+      "integrity": "sha512-HLR38RSF2iulAzc3I/sma4CoYxQP844rPYCNfzGDOHqa/YqVlwuuZgBx6M50/X8dKgzk0cm1qRg3+47mK2N+cQ==",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
@@ -2813,6 +2822,13 @@
         "rc": "cli.js"
       }
     },
+    "node_modules/rc/node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true,
+      "optional": true
+    },
     "node_modules/rc/node_modules/strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
@@ -3638,6 +3654,12 @@
         "@types/minimatch": "*",
         "@types/node": "*"
       }
+    },
+    "@types/ini": {
+      "version": "1.3.31",
+      "resolved": "https://registry.npmjs.org/@types/ini/-/ini-1.3.31.tgz",
+      "integrity": "sha512-8ecxxaG4AlVEM1k9+BsziMw8UsX0qy3jYI1ad/71RrDZ+rdL6aZB0wLfAuflQiDhkD5o4yJ0uPK3OSUic3fG0w==",
+      "dev": true
     },
     "@types/json-schema": {
       "version": "7.0.11",
@@ -4952,11 +4974,9 @@
       "dev": true
     },
     "ini": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-      "dev": true,
-      "optional": true
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.0.tgz",
+      "integrity": "sha512-HLR38RSF2iulAzc3I/sma4CoYxQP844rPYCNfzGDOHqa/YqVlwuuZgBx6M50/X8dKgzk0cm1qRg3+47mK2N+cQ=="
     },
     "is-binary-path": {
       "version": "2.1.0",
@@ -5604,6 +5624,13 @@
         "strip-json-comments": "~2.0.1"
       },
       "dependencies": {
+        "ini": {
+          "version": "1.3.8",
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+          "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+          "dev": true,
+          "optional": true
+        },
         "strip-json-comments": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sops-edit",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "sops-edit",
-      "version": "0.0.10",
+      "version": "0.0.11",
       "dependencies": {
         "@types/vscode": "^1.78.0",
         "@vscode/vsce": "^2.19.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "sops-edit",
   "displayName": "SOPS easy edit",
   "description": "Never again worry about encrypting, decrypting or accidentally committing decrypted files.",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "publisher": "ShipitSmarter",
   "author": {
     "name": "ShipitSmarter",

--- a/package.json
+++ b/package.json
@@ -62,16 +62,16 @@
         }
       ],
       "editor/title": [
-				{
-					"when": "sops-edit.isEncrypted",
-					"command": "sops-edit.decrypt-editor",
-					"group": "navigation"
-				},
         {
-					"when": "sops-edit.isEncryptable",
-					"command": "sops-edit.encrypt-editor",
-					"group": "navigation"
-				}
+          "when": "sops-edit.isEncrypted",
+          "command": "sops-edit.decrypt-editor",
+          "group": "navigation"
+        },
+        {
+          "when": "sops-edit.isEncryptable",
+          "command": "sops-edit.encrypt-editor",
+          "group": "navigation"
+        }
       ]
     },
     "configuration": {
@@ -101,6 +101,7 @@
   },
   "devDependencies": {
     "@types/glob": "^7.2.0",
+    "@types/ini": "^1.3.31",
     "@types/mocha": "^9.1.0",
     "@types/node": "14.x",
     "@types/vscode": "^1.78.0",
@@ -123,10 +124,11 @@
   },
   "icon": "img/sops_easy_edit_logo.png",
   "dependencies": {
-    "@vscode/vsce": "^2.19.0",
     "@types/vscode": "^1.78.0",
+    "@vscode/vsce": "^2.19.0",
     "child_process": "^1.0.2",
     "fs": "^0.0.1-security",
+    "ini": "^4.1.0",
     "yaml": "^2.2.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "auto"
   ],
   "activationEvents": [
-    "*"
+    "workspaceContains:**/.sops.yaml"
   ],
   "main": "./out/extension.js",
   "contributes": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,9 +10,9 @@ export function activate(context: ExtensionContext) {
 		workspace.onDidOpenTextDocument(async (textDocument:TextDocument) => await filePool.openTextDocumentListener(textDocument)),
 		workspace.onDidCloseTextDocument( (textDocument:TextDocument) => filePool.closeTextDocumentListener(textDocument)),
 		workspace.onDidSaveTextDocument( (textDocument:TextDocument) => filePool.saveTextDocumentListener(textDocument)),
-		window.onDidChangeActiveTextEditor((editor:TextEditor|undefined) => EditorContext.set(editor)),
+		window.onDidChangeActiveTextEditor((editor:TextEditor|undefined) => EditorContext.set(editor, filePool)),
 		commands.registerCommand('sops-edit.direct-edit', (_, files:Uri[]) => filePool.editDirectly(files)),
-		commands.registerCommand('sops-edit.decrypt-editor', (uri:Uri) => decryptCommand(uri)),
-		commands.registerCommand('sops-edit.encrypt-editor', (uri:Uri) => encryptCommand(uri))
+		commands.registerCommand('sops-edit.decrypt-editor', (uri:Uri) => decryptCommand(uri, filePool)),
+		commands.registerCommand('sops-edit.encrypt-editor', (uri:Uri) => encryptCommand(uri, filePool))
 	);
 }

--- a/src/utilities/EditorContext.ts
+++ b/src/utilities/EditorContext.ts
@@ -1,12 +1,20 @@
 import { TextEditor, commands } from "vscode";
 import { isOpenedInPlainTextEditor, isEncryptable, isEncrypted, isTooLargeToConsider} from "./functions";
+import { FilePool } from "./FilePool";
 
 export class EditorContext {
-    public static set(editor:TextEditor|undefined) : void {
-        void this._setAsync(editor);
+    public static set(editor:TextEditor|undefined, filePool: FilePool) : void {
+        void this._setAsync(editor, filePool);
     }
 
-    private static async _setAsync(editor:TextEditor|undefined) : Promise<void> {
+    private static async _setAsync(editor:TextEditor|undefined, filePool: FilePool) : Promise<void> {
+        const isOpenTmpFileBool = editor ?  filePool.containsTempFile(editor.document.uri) : false;
+        if (isOpenTmpFileBool) {
+            void this._setEncryptable(false);
+            void this._setEncrypted(false);
+            return;
+        }
+
         const isOpenedInPlainTextEditorBool = editor ? await isOpenedInPlainTextEditor(editor.document.uri) : false;
         if (!isOpenedInPlainTextEditorBool) {
             void this._setEncryptable(false);

--- a/src/utilities/EditorContext.ts
+++ b/src/utilities/EditorContext.ts
@@ -1,5 +1,5 @@
 import { TextEditor, commands } from "vscode";
-import { isOpenedInPlainTextEditor, isSopsEncryptable, isEncryptableAndEncrypted} from "./functions";
+import { isOpenedInPlainTextEditor, isEncryptable, isEncrypted, isTooLargeToConsider} from "./functions";
 
 export class EditorContext {
     public static set(editor:TextEditor|undefined) : void {
@@ -14,16 +14,23 @@ export class EditorContext {
             return;
         }
 
-        const isSopsEncryptableBool = editor ? await isSopsEncryptable(editor.document.uri) : false;
-        if (!isSopsEncryptableBool) {
+        const isTooLargeToConsiderBool = editor ? await isTooLargeToConsider(editor.document.uri) : false;
+        if (isTooLargeToConsiderBool) {
+            void this._setEncryptable(false);
+            void this._setEncrypted(false);
+            return;
+        }
+
+        const isEncryptableBool = editor ? await isEncryptable(editor.document.uri) : false;
+        if (!isEncryptableBool) {
             void this._setEncryptable(false);
             void this._setEncrypted(false);
             return;
         }
         
-        const isEncryptableAndEncryptedBool = editor ? await isEncryptableAndEncrypted(editor.document.uri) : false;
-        if (isSopsEncryptableBool) {
-            if (isEncryptableAndEncryptedBool) {
+        const isEncryptedBool = editor ? isEncrypted(editor.document.uri) : false;
+        if (isEncryptableBool) {
+            if (isEncryptedBool) {
                 void this._setEncryptable(false);
                 void this._setEncrypted(true);
                 return;

--- a/src/utilities/FilePool.ts
+++ b/src/utilities/FilePool.ts
@@ -79,6 +79,10 @@ export class FilePool {
         void f.openFile(directEditFile);
     }
 
+    public containsTempFile(tempFile:Uri) : boolean {
+        return this._getTempFileIndex(tempFile) !== -1;
+    }
+
     private async _editDecryptedTmpCopy(encryptedFile: Uri) : Promise<void> {
         const tempFile = f.getTempUri(encryptedFile);
     

--- a/src/utilities/functions.ts
+++ b/src/utilities/functions.ts
@@ -225,7 +225,7 @@ export async function isEncryptableAndEncrypted(file:Uri) : Promise<boolean> {
 				}
 			}
 		} catch (error) {
-			void window.showInformationMessage(`Could not parse file ${file.path.replace(/^[\s\S]*[/\\]/, '')} as yaml or json`);
+			return false;
 		}
 	}
 


### PR DESCRIPTION
- Fixed file encryption detection for `.env` and `.ini` files (solves [#15](https://github.com/ShipitSmarter/vscode-sops-edit/issues/15))
- Fixed editor showing `encrypt` button for decrypted `tmp` files
- Extension will now only activate for workspaces containing at least one `.sops.yaml` file
-- fixes #15 